### PR TITLE
Adding JBossWS project

### DIFF
--- a/app/data/projects.json
+++ b/app/data/projects.json
@@ -372,6 +372,13 @@
     "category": "Middleware"
   },
   {
+    "projectName": "jbossws",
+    "projectDescription": "Web Services framework and tools for WildFly and JBoss EAP",
+    "projectRepository": "https://github.com/jbossws",
+    "projectWebsite": "http://jbossws.jboss.org/",
+    "category": "Middleware"
+  },
+  {
     "projectName": "JSFUnit",
     "projectDescription": "Test Framework for JSF Applications",
     "projectRepository": "https://github.com/jsfunit",


### PR DESCRIPTION
The JBossWS project is active and definitely relevant. So it has to be added to the project list.