### PR TITLE
Add the RH Documentation GH project.

### DIFF
--- a/app/data/projects.json
+++ b/app/data/projects.json
@@ -441,6 +441,13 @@
     "category": "Middleware"
   },
   {
+  "projectName": "Red Hat Documentation",
+  "projectDescription": "The location for fully open-sourced, freely accessible content on standards and conventions that relate to Red Hat's product documentation.",
+  "projectRepository": "https://github.com/redhat-documentation",
+  "projectWebsite": "https://redhat-documentation.github.io/",
+  "category": "Documentation"
+  },
+  {
     "projectName": "RESTEasy",
     "projectDescription": "Provides various frameworks to help you build RESTful Web Services and RESTful Java applications",
     "projectRepository": "https://github.com/resteasy",

--- a/app/data/projects.json
+++ b/app/data/projects.json
@@ -197,6 +197,13 @@
     "category": "Documentation"
   },
   {
+  "projectName": "Red Hat Documentation",
+  "projectDescription": "The location for fully open-sourced, freely accessible content on standards and conventions that relate to Red Hat's product documentation.",
+  "projectRepository": "https://github.com/redhat-documentation",
+  "projectWebsite": "https://redhat-documentation.github.io/",
+  "category": "Documentation"
+  },
+  {
     "projectName": "Zanata",
     "projectDescription": "Web-based system for translators to translate documentation and software online ",
     "projectRepository": "https://github.com/zanata",
@@ -439,13 +446,6 @@
     "projectRepository": "https://github.com/hodrigohamalho/jboss-migration",
     "projectWebsite": "https://developers.redhat.com/products/rhamt/overview/",
     "category": "Middleware"
-  },
-  {
-  "projectName": "Red Hat Documentation",
-  "projectDescription": "The location for fully open-sourced, freely accessible content on standards and conventions that relate to Red Hat's product documentation.",
-  "projectRepository": "https://github.com/redhat-documentation",
-  "projectWebsite": "https://redhat-documentation.github.io/",
-  "category": "Documentation"
   },
   {
     "projectName": "RESTEasy",


### PR DESCRIPTION
Please, merge to add the GH project that houses RH documentation teams' repos with conventions, guidelines, etc. relating to RH product docs.