### PR TITLE
Use the .org URL for OpenShift

### DIFF
--- a/app/data/projects.json
+++ b/app/data/projects.json
@@ -792,7 +792,7 @@
     "projectName": "OpenShift Origin",
     "projectDescription": "Platform as a Service",
     "projectRepository": "https://github.com/openshift",
-    "projectWebsite": "https://www.openshift.com",
+    "projectWebsite": "https://www.openshift.org",
     "category": "Operations"
   },
   {


### PR DESCRIPTION
The .com domain seems to be more for the product than the project.