### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+node_js:
+  - "node"
+dist: trusty
+addons:
+  apt:
+    packages:
+      - jq
+
+script:
+  # Test commands in package.json
+  - npm install babel-cli
+  - mkdir -p build
+  - npm run-script babel
+  - npm run-script build
+  # Be sure that all provided URLs are valid
+  - set -e && for url in $(jq .[].projectWebsite app/data/projects.json | tr -d \"); do if [ "$url" != "null" ]; then echo "${url}"; curl "${url}" -o /dev/null --fail -L; fi; done
+  - set -e && for url in $(jq .[].projectRepository app/data/projects.json | tr -d \"); do if [ "$url" != "null" ]; then echo "${url}"; curl "${url}" -o /dev/null --fail -L; fi; done


### PR DESCRIPTION
If you enable a connection through Travis CI, this will test that your build commands still work as well as test that all the URLs specified in the data/projects.json file are valid.