### PR TITLE
Use HTTPS for oVirt's site

### DIFF
--- a/app/data/featured.json
+++ b/app/data/featured.json
@@ -20,7 +20,7 @@
   "name": "oVirt",
   "logo": "ovirt",
   "github": "https://github.com/ovirt",
-  "website": "http://ovirt.org",
+  "website": "https://ovirt.org",
   "description": "An open source virtualization platform powered by KVM on Linux<sup>&reg;</sup> with an easy-to-use web interface that manages virtual machines, storage, and networks."
 },{
   "name": "Project Atomic",

--- a/app/data/projects.json
+++ b/app/data/projects.json
@@ -1110,7 +1110,7 @@
     "projectName": "oVirt",
     "projectDescription": "Open virtual datacenter",
     "projectRepository": "https://github.com/ovirt",
-    "projectWebsite": "http://ovirt.org",
+    "projectWebsite": "https://ovirt.org",
     "category": "Operations"
   },
   {


### PR DESCRIPTION
While http://ovirt.org works just fine, there's no reason not use the
secure variant https://ovirt.org