### PR TITLE
Added wording to clarify the scope of project

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ At this time, only projects that Red Hat employees are required to work on as pa
 
 ### What about projects not on GitHub?
 
-This list is just for Red Hat contributions to projects hosted on GitHub.  See https://community.redhat.com/software/ for more comprehensive listing of Red Hat's contributions to free and open source projects, regardless of where they are hosted.
+This list is just for Red Hat contributions to projects hosted on GitHub.  See https://community.redhat.com/software/ for a more comprehensive listing of Red Hat's contributions to free and open source projects, regardless of where they are hosted.
 
 ## Built with
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Red Hat on GitHub
 
-We’ve put together a comprehensive list of the projects hosted on GitHub in which Red Hat employees are actively involved. Given the large scope of our open source work, we recognize that we might have missed some projects or gotten a listing wrong. As time passes, more projects will need to be added to the list. These circumstances, and others we can’t currently foresee, may mean you’ll want to make changes to this list. So, how do you do that?
+We’ve put together a comprehensive list of the projects hosted on GitHub in which Red Hat employees are actively involved. Given the large scope of our open source work, we recognize that we might have missed some projects or gotten a listing wrong. As time passes, more projects with which Red Hat employees collaborate will need to be added to the list. These circumstances, and others we can’t currently foresee, may mean you’ll want to make changes to this list. So, how do you do that?
 
 ## Adding a project
 
@@ -32,10 +32,11 @@ Current categories include:
 
 ### Criteria for adding projects to the page
 
-At this time, only projects that Red Hat employees are required to work on as part of their job will be listed. There are so many amazing projects that Red Hatters work on as enthusiasts, too many to recognize in one place. This criteria may be subject to change as the page evolves.
+At this time, only projects that Red Hat employees are required to work on as part of their job will be listed. This includes projects Red Hat stewards as well as projects in which Red Hat is just one contributor among others. There are so many amazing projects that Red Hatters work on as enthusiasts, too many to recognize in one place. This criteria may be subject to change as the page evolves.
 
 ### What about projects not on GitHub?
-This list is just for Red Hat contributions to projects hosted on GitHub.  See https://community.redhat.com/software/ for an attempt at listing Red Hat's contributions to the broader universe of FLOSS projects.
+
+This list is just for Red Hat contributions to projects hosted on GitHub.  See https://community.redhat.com/software/ for more comprehensive listing of Red Hat's contributions to free and open source projects, regardless of where they are hosted.
 
 ## Built with
 


### PR DESCRIPTION
This is trying to address the comments made in #56 , to explicitly describe the projects as those Red Hat "stewards," and those Red Hat contributes to as part of a broader set of individual and corporate contributors. @dmsimard @davidmalcolm can you take a look to see if this is a better description in the README file?