### PR TITLE
Remove duplicate entry for minishift project

### DIFF
--- a/app/data/projects.json
+++ b/app/data/projects.json
@@ -1090,12 +1090,6 @@
     "category": "Operations"
   },
   {
-    "projectName": "minishift",
-    "projectDescription": "Run Openshift Locally",
-    "projectRepository": "https://github.com/minishift",
-    "category": "Operations"
-  },
-  {
     "projectName": "Moby Project",
     "projectDescription": "A collaborative project for the container ecosystem to assemble container-based systems",
     "projectRepository": "https://github.com/moby/moby/",


### PR DESCRIPTION
Currently minishift project listed twice and it shouldn't be part of `Operational` group so removed the duplicate entry.