### PR TITLE
Add Open Practice Library

### DIFF
--- a/app/data/projects.json
+++ b/app/data/projects.json
@@ -1611,7 +1611,7 @@
     "projectDescription": "Documentation on the practices used in Red Hat Open Innovation Labs residencies",
     "projectRepository": "https://github.com/rht-labs/practice-library/",
     "projectWebsite": "https://rht-labs.github.io/practice-library/",
-    "category": "Documentation"
+    "category": "Organizations"
   },
   {
     "projectName": "Open Source and Standards",


### PR DESCRIPTION
This PR adds the [Open Practice Library](https://rht-labs.github.io/practice-library/) to the list of projects.

Thank you! :smile: 