### PR TITLE
Add project website for Red Hat Middleware Node.js

### DIFF
--- a/app/data/projects.json
+++ b/app/data/projects.json
@@ -430,6 +430,7 @@
     "projectName": "Red Hat Middleware Node.js",
     "projectDescription": "Red Hat Middleware Node.js projects and research",
     "projectRepository": "https://github.com/nodeshift",
+    "projectWebsite": "https://nodeshift.dev/",
     "category": "Development"
   },
   {


### PR DESCRIPTION
Adds the project website for Red Hat Middleware Node.js: https://nodeshift.dev/