### PR TITLE
Card footer website link scss fix

### DIFF
--- a/app/components/card/card.scss
+++ b/app/components/card/card.scss
@@ -57,6 +57,7 @@
         }
         &-icon {
             @extend %link-icon;
+	    display: flex;
         }
     }
 }


### PR DESCRIPTION
## Card footer link was broken (website icon and text)

fixed the scss . 