### PR TITLE
Removes extra build command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,6 @@ jobs:
         run: |
           npm install
           mkdir -p build
-          npm run babel
           npm run build
 
       - name: Deploy 🚀


### PR DESCRIPTION
Updates deploy build command. Not sure how the old one ever worked. 🤔 

### Related issue

- (#291) Request to make linux-system-roles available in https://redhatofficial.github.io


### Testing instructions

1. Updates to the `dev` branch should deploy to https://redhatofficial.github.io

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.
