### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Validate URLs
         # Only run this if these files were edited
         if: contains(steps.files.outputs.added_modified, 'app/data/*.json')
-        uses: urlstechie/urlchecker-action@0.2.1
+        uses: urlstechie/urlchecker-action@0.0.27
         with:
           # Only validate the files that were changed
           include_files: ${{ steps.files.outputs.added_modified }}


### PR DESCRIPTION
We are going to be deprecating older versions of urlchecker (and there was a change in versioning to match the upstream package so the version only appears earlier) so I wanted to update here to make sure your workflows do not break! To be clear, 0.0.27 is actually the newest release. https://github.com/urlstechie/urlchecker-action/releases/tag/0.0.27

The updated versions also run about 7x as fast, so that's an added bonus!

<!--- Thank you for opening a pull request. Please be sure to review our [Contribution guidelines](CONTRIBUTING.md) and be sure to adhere to our [Code of conduct](CODE_OF_CONDUCT.md) when interacting with the community. --->

<!-- tldr; goes here. Give us a really high-level summary of these changes. -->

### Related issue

- (#100) Description


### Testing instructions

<!-- Be sure to include detailed instructions on how your update can be tested by another developer. -->

1. 


#### Browser requirements (for page updates)

Your updates should work in the following environments:

- [ ] Latest 2 versions of Edge
- [ ] Internet Explorer 11 (should be useable, not pixel perfect)
- [ ] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [ ] Firefox 68 (or latest version for Red Hat Enterprise Linux distribution)
- [ ] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [ ] Latest 2 versions of Safari
- [ ] Android mobile device (such as the Galaxy S9)
- [ ] Apple mobile device (such as the iPhone X)
- [ ] Apple tablet device (such as the iPhone Pro)


### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [ ] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [ ] Browser testing passed.
- [ ] Repository compiles.
- [ ] Documentation (README.md, etc.) updated or added.
- [ ] Approved by designer or writer (if applicable).


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.
