### PR TITLE
fix: resolve OpenSSL compatibility issue in dev server by setting NODE_OPTIONS

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "babel": "babel --presets es2015 app/index.js -o dist/bundle.js",
     "build": "webpack --config webpack.config.prod.js --mode production",
-    "start": "webpack-dev-server --mode development --open --config webpack.config.dev.js",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider webpack-dev-server --mode development --open --config webpack.config.dev.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",


### PR DESCRIPTION
## Summary

- Fixes OpenSSL compatibility issue by setting `NODE_OPTIONS` in the development server command.

## Related Issue

- Closes #100

## Testing Instructions

1. Pull this branch and run `npm start`.
2. Confirm `webpack-dev-server` starts without OpenSSL errors.
3. Verify the app loads at `http://localhost:8080`.

## Browser Testing

- Tested on: Latest version of Chrome.

## Ready-to-Merge Checklist

- [x] All changes are related to the issue.
- [x] Browser testing completed on Chrome.
- [x] Project compiles without errors.
- [ ] Documentation updated, if needed.

---