### PR TITLE
Create Dockerfile to allow it to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:11.0.0-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies (including devDependencies for build)
+RUN npm ci
+
+# Install serve to serve static files
+RUN npm install -g serve
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Expose port
+EXPOSE 3000
+
+# Serve the built application from dist directory
+CMD ["serve", "-s", "dist", "-l", "3000"]
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.0.0-slim
+FROM node:14-slim
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
This creates a dockerfile in the repo using an older (likely EOL) version of node that allows the site to be built and run.

This may be helpful for testing and/or any efforts to slowly upgrade things to modern, supported versions

tested by finding a project thats present in the docs (i.e. recently added) but not on the site (Kuadrant) and confirming that the site built with this container indeed includes that project (in fact its in there twice!) 

claude did most of the work writing the dockerfile - i just iterated through old node versions  starting with node 11 and getting newer until one worked

Utter worst case, this PR serves as documentation that the site build seems to work on node 14