### PR TITLE
fix: close overlay on mobile nav after hash link click

### DIFF
--- a/static/js/page.js
+++ b/static/js/page.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const mainNavHashLinks = document.querySelectorAll(
+        'rh-navigation-primary-item[href^="#"], rh-navigation-primary-item > a[href^="#"]'
+    );
+
+    for (let hashLink of mainNavHashLinks) {
+        hashLink.addEventListener('click', function() {
+            hashLink.closest('rh-navigation-primary').close();
+        });
+    }
+});

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', function() {
         'rh-navigation-primary-item[href^="#"], rh-navigation-primary-item > a[href^="#"]'
     );
 
-        // Close dropdowns after clicking an in-page link on mobile viewports
+    // Close dropdowns after clicking an in-page link on mobile viewports
     for (let hashLink of mainNavHashLinks) {
         hashLink.addEventListener('click', function() {
             hashLink.closest('rh-navigation-primary').close();

--- a/static/js/page.js
+++ b/static/js/page.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', function() {
         'rh-navigation-primary-item[href^="#"], rh-navigation-primary-item > a[href^="#"]'
     );
 
+        // Close dropdowns after clicking an in-page link on mobile viewports
     for (let hashLink of mainNavHashLinks) {
         hashLink.addEventListener('click', function() {
             hashLink.closest('rh-navigation-primary').close();

--- a/templates/index.html
+++ b/templates/index.html
@@ -116,6 +116,7 @@
 
 {% include "partials/_footer.html" %}
 
+<script src="/js/page.js"></script>
 <script src="/js/table-search.js"></script>
 <script src="/js/rht-picture.js"></script>
 


### PR DESCRIPTION
<!--- Thank you for opening a pull request. Please be sure to review our [Contribution guidelines](CONTRIBUTING.md) and be sure to adhere to our [Code of conduct](CODE_OF_CONDUCT.md) when interacting with the community. --->

- Mobile nav overlay (when open) now closes when a hash link is clicked.

## Testing / Issue

1. Open navigation on mobile on [live site](https://redhatofficial.github.io/)
2. Click `Projects` or `Contribute` 
3. Notice the overlay doesn't disappear
4. Compare with local dev branch
