### PR TITLE
Fix dropdown visibility in dark mode (Issue #389)

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -426,4 +426,16 @@
       --rh-icon-size: 10px;
     }
   }
+
+        /* Fix for dark mode dropdown visibility - Issue #389 */
+[data-theme="dark"] #table-search-dropdown {
+  background-color: var(--pf-global--BackgroundColor--dark-100, #1f1f1f);
+  color: var(--pf-global--Color--light-100, #ffffff);
+  border-color: var(--pf-global--BorderColor--dark-100, #6a6e73);
+}
+
+[data-theme="dark"] #table-search-dropdown option {
+  background-color: var(--pf-global--BackgroundColor--dark-100, #1f1f1f);
+  color: var(--pf-global--Color--light-100, #ffffff);
+}
 }


### PR DESCRIPTION
Added CSS rules to fix the 'Filter by category' dropdown visibility in dark mode.

The dropdown previously had white text on white background in dark mode, making the options unreadable. This fix:
- Sets dark background color for the dropdown in dark mode
- Sets light text color for better contrast
- Ensures dropdown options are also properly styled

Resolves #389