### PR TITLE
Fix footer link conditional checks

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -44,22 +44,23 @@
                             </a>
                         </li>
                         {% endif %}
-                        {% if feature.website %}
-                        <li>
-                            <a href="{{ feature.twitter }}" aria-label="{{ feature.name }} x account">
-                                <rh-icon set="social" icon="x" aria-label="X"></rh-icon>
-                                Account
-                            </a>
-                        </li>
+                        {% if feature.twitter %}
+                             <li>
+                                <a href="{{ feature.twitter }}" aria-label="{{ feature.name }} x account">
+                                    <rh-icon set="social" icon="x" aria-label="X"></rh-icon>
+                                    Account
+                                </a>
+                            </li>
                         {% endif %}
-                        {% if feature.website %}
-                        <li>
+
+                        {% if feature.github %}
+                            <li>
                             <a href="{{ feature.github }}" aria-label="{{ feature.name }} GitHub repo">
-                                <rh-icon set="social" icon="github" aria-label="GitHub"></rh-icon>
-                                Repo
+                            <rh-icon set="social" icon="github" aria-label="GitHub"></rh-icon>
+                          Repo
                             </a>
-                        </li>
-                        {% endif %}
+                            </li>
+                        {% endif %} 
                     </ul>
                     {% endif %}
                 </rh-card>


### PR DESCRIPTION
Fix incorrect conditional checks for featured project footer links in templates/index.html.

bug:#396

The Twitter/X and GitHub footer links were incorrectly checking feature.website before rendering. This caused the links to be hidden when a project had a Twitter or GitHub URL but no website configured.

Changes
Replaced feature.website with feature.twitter for the X account link condition
Replaced feature.website with feature.github for the GitHub repo link condition
Result

Each footer link now renders based on its own corresponding field.