### PR TITLE
Fix wrong conditional checks for Twitter/GitHub links in featured cards

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -44,7 +44,7 @@
                             </a>
                         </li>
                         {% endif %}
-                        {% if feature.website %}
+                        {% if feature.twitter %}
                         <li>
                             <a href="{{ feature.twitter }}" aria-label="{{ feature.name }} x account">
                                 <rh-icon set="social" icon="x" aria-label="X"></rh-icon>
@@ -52,7 +52,7 @@
                             </a>
                         </li>
                         {% endif %}
-                        {% if feature.website %}
+                        {% if feature.github %}
                         <li>
                             <a href="{{ feature.github }}" aria-label="{{ feature.name }} GitHub repo">
                                 <rh-icon set="social" icon="github" aria-label="GitHub"></rh-icon>


### PR DESCRIPTION
## Summary

The featured project cards in `templates/index.html` had incorrect conditional checks for the Twitter and GitHub link blocks. Both blocks checked `feature.website` instead of their respective variables:

- **Line 47**: `{% if feature.website %}` guarded the Twitter link — changed to `{% if feature.twitter %}`
- **Line 55**: `{% if feature.website %}` guarded the GitHub link — changed to `{% if feature.github %}`

This caused two problems:
1. Twitter/GitHub links would render (with potentially empty `href`) whenever a website URL existed, even if no Twitter/GitHub URL was set
2. Twitter/GitHub links would be hidden when only those URLs were set without a website URL

## Verification

- Confirmed the bug exists by grepping for `feature.website` on the affected lines
- Verified each `{% if %}` conditional now matches its corresponding `<a href>` target
- The outer `{% if feature.website or feature.github or feature.twitter %}` guard on line 37 remains correct

Fixes #396